### PR TITLE
Fix README trailing line

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,3 @@ To install Experimental LabStore, follow these steps:
 
 ### Para solucionar error "Error on ghost text request: FetchError: The pending stream has been canceled (caused by: self signed certificate in certificate chain)" en Github Copilot: 
 $env:NODE_TLS_REJECT_UNAUTHORIZED="0"
-code .


### PR DESCRIPTION
## Summary
- remove stray `code .` line from README

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401bd2a95883328abadbb310cff97b