### PR TITLE
Fix usage port

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install Experimental LabStore, follow these steps:
 
 ## Usage
 1. Start the server: `python -m streamlit run .\lab.py`
-2. Open your web browser and navigate to `http://localhost:5000` 
+2. Open your web browser and navigate to `http://localhost:8501`
 3. You can now interact with the system, add inventory items, track usage, and automate restocking routines. For more details, please refer to the user manual included in the project documentation.
 
 


### PR DESCRIPTION
## Summary
- use default Streamlit port in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401f7e21c083328f320ef953b0b57f