### PR TITLE
Fix import header

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -1,4 +1,3 @@
-\
 import io
 from reportlab.lib.pagesizes import letter
 from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Image, Table, TableStyle, PageBreak


### PR DESCRIPTION
## Summary
- remove stray backslash from `report_generator.py`

## Testing
- `python -m py_compile report_generator.py`
- `python - <<'PY'
import report_generator
print('module name:', report_generator.__name__)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68401f5d47508332b37bb5db5c2fc252