### PR TITLE
Add explanatory comments to tests

### DIFF
--- a/tests/test_calibraciones.py
+++ b/tests/test_calibraciones.py
@@ -1,0 +1,20 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pandas as pd
+
+from pages.Calibraciones import CalibrationApp
+
+
+def test_generar_plantilla_excel():
+    """Comprueba que la plantilla Excel tiene las columnas correctas y una fila de ceros."""
+    app = CalibrationApp()
+    output = app._generar_plantilla_excel()
+    output.seek(0)
+    df = pd.read_excel(output)
+    expected_cols = [
+        'PAT1_0', 'DUT1_0', 'PAT1_R', 'DUT1_R',
+        'PAT2_0', 'DUT2_0', 'PAT2_R', 'DUT2_R',
+        'PAT3_0', 'DUT3_0', 'PAT3_R', 'DUT3_R'
+    ]
+    assert df.columns.tolist() == expected_cols
+    assert (df.iloc[0] == 0).all()

--- a/tests/test_rotations.py
+++ b/tests/test_rotations.py
@@ -1,0 +1,14 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pandas as pd
+import io
+
+from pages.Rotations import to_excel
+
+
+def test_to_excel_roundtrip():
+    """Verifica que to_excel escriba y lea sin modificar el DataFrame."""
+    df = pd.DataFrame({'A': [1, 2], 'B': [3, 4]})
+    excel_bytes = to_excel(df)
+    read_df = pd.read_excel(io.BytesIO(excel_bytes))
+    pd.testing.assert_frame_equal(read_df, df)


### PR DESCRIPTION
## Summary
- add docstrings to clarify each new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840766bb5cc8332928d621af222f74a