### PR TITLE
Fix session state update for date/time

### DIFF
--- a/pages/Data_Explorer.py
+++ b/pages/Data_Explorer.py
@@ -233,8 +233,6 @@ class DataExplorer:
                 value=st.session_state.get("offset_time", time(0, 0)),
                 key="offset_time",
             )
-            st.session_state.offset_date = offset_date
-            st.session_state.offset_time = offset_time
             offset_seconds = (
                 offset_time.hour * 3600
                 + offset_time.minute * 60


### PR DESCRIPTION
## Summary
- prevent session state modification of `offset_date` and `offset_time` widgets after instantiation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419cc4606c833295e1557d410d4b18