### PR TITLE
Add waveform data analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Experimental LabStore es una aplicación modular basada en Streamlit que reúne 
   - **Calibraciones.py** – Herramienta completa para calibrar celdas de carga. Genera gráficos, calcula errores y produce informes PDF detallados.
   - **Cálculo_Tracción_KC-390.py** – Calcula la fuerza de tracción a partir de diámetros y durezas, con opción de guardar resultados en PDF.
   - **Calculadora_de_Tiempo.py** – Calcula la fecha y hora de finalización de un ensayo a partir de la hora de inicio y la duración.
+  - **Arbitrary_Waveform_Script_Generator.py** – Genera scripts de forma de onda a partir de archivos Excel.
   - **wip/** – Contiene módulos en desarrollo (por ejemplo, Graficador e Instrumentos).
 - **utils.py** y **report_generator.py** ofrecen funciones de apoyo para el manejo de `st.session_state` y la generación de informes en PDF.
 - Los directorios **data/** y **resources/** incluyen archivos de ejemplo y material de apoyo como imágenes o tablas de dureza Rockwell.
@@ -54,6 +55,7 @@ Experimental LabStore is a modular Streamlit application that gathers various to
   - **Calibraciones.py** – Full load cell calibration tool. Creates charts, computes errors and builds detailed PDF reports.
   - **Cálculo_Tracción_KC-390.py** – Calculates traction force from diameter and hardness values with an option to save results in PDF.
   - **Calculadora_de_Tiempo.py** – Computes the end date and time of a test from its start time and duration.
+  - **Arbitrary_Waveform_Script_Generator.py** – Generates waveform scripts from Excel files.
   - **wip/** – Contains work-in-progress modules such as Graficador and Instrumentos.
 - **utils.py** and **report_generator.py** provide helpers for `st.session_state` management and PDF report generation.
 - The **data/** and **resources/** folders include sample files and supporting assets like images or Rockwell hardness tables.

--- a/config.py
+++ b/config.py
@@ -37,4 +37,5 @@ def page_config(title, icon, layout: Literal["centered", "wide"] = "centered"):
         st.page_link("pages/Data_Explorer.py", label="Explorador de Datos", icon="📊")
         st.page_link("pages/Rotations.py", label="Rotations", icon="🔄")
         st.page_link("pages/Calibraciones.py", label="Calibraciones", icon="⚖️")
+        st.page_link("pages/Arbitrary_Waveform_Script_Generator.py", label="AWF Script Generator", icon="📜")
         

--- a/lab.py
+++ b/lab.py
@@ -34,6 +34,8 @@ class PlayStoreApp:
                 st.page_link('pages/Calculadora_FTC.py', label='Frecuencia y Ciclos', icon="♾️", help=None, disabled=False, use_container_width=True)
             with st.container(height=60, border=True):
                 st.page_link('pages/Calibraciones.py', label='Calibraciones', icon="⚖️", help=None, disabled=False, use_container_width=True)
+            with st.container(height=60, border=True):
+                st.page_link('pages/Arbitrary_Waveform_Script_Generator.py', label='AWF Script Generator', icon="📜", help=None, disabled=False, use_container_width=True)
            
         st.markdown("---")
         st.markdown('<h3>Contacto:</h3>', unsafe_allow_html=True)

--- a/pages/Arbitrary_Waveform_Script_Generator.py
+++ b/pages/Arbitrary_Waveform_Script_Generator.py
@@ -1,0 +1,100 @@
+import pandas as pd
+import streamlit as st
+
+from config import page_config
+
+
+def validate_format(df: pd.DataFrame) -> str | None:
+    if df.shape[1] < 2 or df.empty:
+        return "El archivo debe tener al menos dos columnas y una fila de datos."
+
+    time_unit = str(df.iloc[0, 0]).strip()
+    volt_unit = str(df.iloc[0, 1]).strip()
+
+    if time_unit not in ("us", "ms", "s"):
+        return "Unidad de tiempo inválida en la fila 1, columna A."
+    if volt_unit not in ("uV", "mV", "V"):
+        return "Unidad de voltaje inválida en la fila 1, columna B."
+
+    data = df.iloc[1:, :2]
+    try:
+        data.apply(pd.to_numeric)
+    except Exception:
+        return "Los valores a partir de la fila 2 deben ser numéricos."
+    return None
+
+
+class AWScriptGenerator:
+    def __init__(self):
+        page_config(title="Arbitrary Waveform Script Generator", icon="📜")
+        st.markdown("# Arbitrary Waveform Script Generator")
+        self.layout()
+
+    def layout(self):
+        with st.expander("ℹ️ Formato de archivo", expanded=False):
+            st.markdown(
+                """
+                **Fila 1**
+                - Columna A: unidad de tiempo `[us, ms, s]`
+                - Columna B: unidad de voltaje `[uV, mV, V]`
+
+                **Fila 2 en adelante**
+                - Columna A: tiempo de la muestra
+                - Columna B: voltaje de la muestra
+                """
+            )
+
+        uploaded_file = st.file_uploader(
+            "Cargar archivo XLSX", type=["xlsx"], accept_multiple_files=False
+        )
+
+        if uploaded_file is not None:
+            try:
+                df = pd.read_excel(uploaded_file, header=None)
+            except Exception as e:
+                st.error(f"Error al leer el archivo: {e}")
+                return
+
+            error = validate_format(df)
+            if error:
+                st.error(error)
+                return
+
+            time_unit = str(df.iloc[0, 0]).strip()
+            volt_unit = str(df.iloc[0, 1]).strip()
+            data = df.iloc[1:, :2].astype(float)
+            sample_count = len(data)
+
+            time_factors = {"us": 1e-6, "ms": 1e-3, "s": 1.0}
+            volt_factors = {"uV": 1e-6, "mV": 1e-3, "V": 1.0}
+
+            if sample_count >= 2:
+                dt = data.iloc[1, 0] - data.iloc[0, 0]
+                try:
+                    sample_freq = 1.0 / (dt * time_factors[time_unit])
+                except ZeroDivisionError:
+                    sample_freq = float("inf")
+            else:
+                sample_freq = None
+
+            voltages = data.iloc[:, 1] * volt_factors[volt_unit]
+            volt_df = pd.DataFrame({"Voltage (V)": voltages})
+            v_max = voltages.max()
+            v_min = voltages.min()
+
+            st.success(
+                f"Formato correcto. {sample_count} muestras detectadas."
+            )
+            st.markdown(f"- Unidad de tiempo: **{time_unit}**")
+            st.markdown(f"- Unidad de voltaje: **{volt_unit}**")
+            if sample_freq is not None:
+                st.markdown(f"- Frecuencia de muestreo: **{sample_freq:.3f} Sa/s**")
+            else:
+                st.markdown("- Frecuencia de muestreo: N/A")
+            st.markdown(f"- Voltaje máximo: **{v_max:.3f} V**")
+            st.markdown(f"- Voltaje mínimo: **{v_min:.3f} V**")
+            st.dataframe(volt_df.head(), use_container_width=True)
+
+
+if __name__ == "__main__":
+    AWScriptGenerator()

--- a/tests/test_awsg.py
+++ b/tests/test_awsg.py
@@ -1,0 +1,30 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pandas as pd
+
+from pages.Arbitrary_Waveform_Script_Generator import validate_format
+
+
+def test_validate_format_ok():
+    df = pd.DataFrame([
+        ["ms", "V"],
+        [0, 0],
+        [1, 1],
+    ])
+    assert validate_format(df) is None
+
+
+def test_validate_format_invalid_unit():
+    df = pd.DataFrame([
+        ["min", "V"],
+        [0, 0],
+    ])
+    assert "Unidad de tiempo" in validate_format(df)
+
+
+def test_validate_format_non_numeric():
+    df = pd.DataFrame([
+        ["ms", "V"],
+        ["a", 1],
+    ])
+    assert "num\u00e9ricos" in validate_format(df)


### PR DESCRIPTION
## Summary
- extend Arbitrary Waveform Script Generator with sampling frequency, voltage stats and dataset preview
- document the new page in the README
- test validation helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517fca0be08332b829728978835676